### PR TITLE
Added partitioning guide

### DIFF
--- a/config/hardening/ssg-rhel.cfg
+++ b/config/hardening/ssg-rhel.cfg
@@ -28,6 +28,20 @@ selinux --enforcing
 firstboot --disable
 timezone --utc America/New_York
 
+# Partitioning Settings (CCI-000336)
+ignoredisk --only-use=sda
+clearpart --all --drives=sda
+part /boot --fstype ext4 --size=1024 --ondisk=sda
+part pv.01 --size=100 --grow --ondisk=sda
+volgroup rhel_vg pv.01
+logvol swap --fstype swap --name=swap --vgname=rhel_vg --percent=5
+logvol / --fstype ext4 --name=lv_root --vgname=rhel_vg --percent=30
+logvol /home --fstype ext4 --name=lv_home --vgname=rhel_vg --percent=30 --grow
+logvol /tmp --fstype ext4 --name=lv_tmp --vgname=rhel_vg --percent=5
+logvol /var --fstype ext4 --name=lv_var --vgname=rhel_vg --percent=5
+logvol /var/log --fstype ext4 --name=lv_var_log --vgname=rhel_vg --percent=5
+logvol /var/log/audit --fstype ext4 --name=lv_var_log_audit --vgname=rhel_vg --percent=10
+
 # Include hardening with kickstart options
 %include /tmp/hardening
 %include /tmp/partitioning


### PR DESCRIPTION
According to the current version of the draft RHEL7 STIG, there is still going to be a requirement for CCI-000336 (even though the OpenSCAP guide seems to think otherwise, I have been dinged in on it before in an assessment). This was also a present control in the RHEL5 and RHEL6 STIGs. Although, in the RHEL5 STIG it has been identified as CCI-001208.

I will test this change to the kickstart before submitting a pull request.
