### PR TITLE
Adding prelink Package

### DIFF
--- a/config/hardening/ssg-rhel.cfg
+++ b/config/hardening/ssg-rhel.cfg
@@ -58,6 +58,7 @@ unzip
 bzip2
 zip
 deltarpm
+prelink
 # SmartCard
 pam_pkcs11
 pcsc-lite


### PR DESCRIPTION
Adding prelink package to fix stig finding:
Rationale:
Because the prelinking feature changes binaries, it can interfere with the operation of certain software and/or modes such as AIDE, FIPS, etc.
identifiers:  CCE-27078-5
references:  CM-6(d), CM-6(3), SC-28, SI-7, Req-11.5