### PR TITLE
Remove usbguard-dbus Service

### DIFF
--- a/config/hardening/ssg-rhel.cfg
+++ b/config/hardening/ssg-rhel.cfg
@@ -180,7 +180,6 @@ yum localinstall -y /root/hardening/*cap-*.rpm
 
 # Install USB Guard
 yum localinstall -y /root/hardening/usbguard-*.rpm
-systemctl enable usbguard-dbus.service
 systemctl enable usbguard.service
 
 # Copy over Firefox STIG


### PR DESCRIPTION
The usbguard-dbus service is no longer required.