### PR TITLE
Disable Bluetooth Service

### DIFF
--- a/config/hardening/ssg-rhel.cfg
+++ b/config/hardening/ssg-rhel.cfg
@@ -2,7 +2,7 @@
 # SSG RHEL 7 Kickstart
 #
 # This script was written by Frank Caviggia, Red Hat Consulting
-# Last update was 21 Dec 2015
+# Last update was 21 Nov 2016
 # This script is NOT SUPPORTED by Red Hat Global Support Services.
 # Please contact Peter Glantzis for more information.
 #
@@ -181,6 +181,9 @@ yum localinstall -y /root/hardening/*cap-*.rpm
 # Install USB Guard
 yum localinstall -y /root/hardening/usbguard-*.rpm
 systemctl enable usbguard.service
+
+# Disable Bluetooth Service
+systemctl mask bluetooth.service
 
 # Copy over Firefox STIG
 tar xzf /root/hardening/ssg-firefox.tar.gz -C /usr/share/xml/scap/ssg/content/


### PR DESCRIPTION
Disable bluetooth service since it will not start due to blacklisting the kernel module in /etc/modprobe.d/usgcb-blacklist.conf