### PR TITLE
Miscellaneous Updates

### DIFF
--- a/config/hardening/ssg-supplemental.sh
+++ b/config/hardening/ssg-supplemental.sh
@@ -145,6 +145,8 @@ maxclassrepeat = 2
 # dictpath =
 EOF
 
+echo -e "FAIL_DELAY\t4" >> /etc/login.defs
+
 
 ########################################
 # STIG Audit Configuration
@@ -310,7 +312,7 @@ cat <<EOF > /etc/audit/rules.d/audit.rules
 #2.6.2.4.9 Ensure auditd Collects Information on the Use of Privileged Commands
 EOF
 # Find All privileged commands and monitor them
-for PROG in `find / -type f -perm -04000 -o -type f -perm -2000 2>/dev/null`; do
+for PROG in `find / -type f -perm -4000 -o -type f -perm -2000 2>/dev/null`; do
 	echo "-a always,exit -F path=$PROG -F perm=x -F auid>=1000 -F auid!=4294967295 -k privileged"  >> /etc/audit/rules.d/audit.rules
 done
 cat <<EOF >> /etc/audit/rules.d/audit.rules
@@ -361,8 +363,8 @@ cat /dev/null > /etc/securetty
 cat <<EOF > /etc/profile.d/autologout.sh
 #!/bin/sh
 TMOUT=900
-readonly TMOUT
 export TMOUT
+readonly TMOUT
 EOF
 cat <<EOF > /etc/profile.d/autologout.csh
 #!/bin/csh


### PR DESCRIPTION
Adding FAIL_DELAY=4 to /etc/login.defs and fixing the check for privileged commands on audit by changing find command from 04000 to 4000.