### PR TITLE
Disable Prelinking

### DIFF
--- a/config/hardening/ssg-rhel.cfg
+++ b/config/hardening/ssg-rhel.cfg
@@ -224,7 +224,17 @@ if [ -e /root/anaconda-ks.cfg ]; then
 	rm -f /root/anaconda-ks.cfg
 fi
 
-/root/scap_remediate_system.sh
+########################################
+# Disable Pre-Linking
+# CCE-27078-5
+########################################
+if grep -q ^PRELINKING /etc/sysconfig/prelink; then
+  sed -i 's/PRELINKING.*/PRELINKING=no/g' /etc/sysconfig/prelink
+else
+  echo -e "\n# Disable Pre-Linking (CCE-27078-5, CM-6(d), CM-6(3), SC-28, SI-7, Req-11.5)" >> /etc/sysconfig/prelink
+  echo "PRELINKING=no" >> /etc/sysconfig/prelink
+fi
+/usr/sbin/prelink -ua
 
 /usr/bin/sed -i '/clean_up.sh/d' /etc/rc.local
 rm -f /root/clean_up.sh

--- a/config/hardening/ssg-supplemental.sh
+++ b/config/hardening/ssg-supplemental.sh
@@ -733,19 +733,6 @@ EOF
 	/bin/dconf update
 fi
 
-
-########################################
-# Disable Pre-Linking
-# CCE-27078-5
-########################################
-if grep -q ^PRELINKING /etc/sysconfig/prelink; then
-  sed -i 's/PRELINKING.*/PRELINKING=no/g' /etc/sysconfig/prelink
-else
-  echo -e "\n# Disable Pre-Linking (CCE-27078-5, CM-6(d), CM-6(3), SC-28, SI-7, Req-11.5)" >> /etc/sysconfig/prelink
-  echo "PRELINKING=no" >> /etc/sysconfig/prelink
-fi
-/usr/sbin/prelink -ua
-
 ########################################
 # Kernel - Randomize Memory Space
 # CCE-27127-0, SC-30(2), 1.6.1


### PR DESCRIPTION
Moved the script to disable prelinking from ssg-supplemental.sh to ssg-rhel.cfg as part of the /root/clean_up.sh script executed by /etc/rc.local script.