### PR TITLE
 Fix for SSG SSH Configuration Error

### DIFF
--- a/config/hardening/ssg-rhel.cfg
+++ b/config/hardening/ssg-rhel.cfg
@@ -209,6 +209,9 @@ ssh-keygen -b 1024 -t dsa -N "" -f /etc/ssh/ssh_host_dsa_key
 ssh-keygen -b 521 -t ecdsa -N "" -f /etc/ssh/ssh_host_ecdsa_key
 chmod 0600 /etc/ssh/*_key
 
+# SSG SSH Fix
+/usr/bin/sed -i 's/sha1Cipher/sha1\nCipher/' /etc/ssh/sshd_config
+
 # Clean Up
 rm -rf /root/hardening
 


### PR DESCRIPTION
Fix for SSG SSH configuration error in /etc/ssh/sshd_config that is preventing sshd from starting correctly.