### PR TITLE
SSG SSHD Fix

### DIFF
--- a/config/hardening/ssg-rhel.cfg
+++ b/config/hardening/ssg-rhel.cfg
@@ -211,6 +211,7 @@ chmod 0600 /etc/ssh/*_key
 
 # SSG SSH Fix
 /usr/bin/sed -i 's/sha1Cipher/sha1\nCipher/' /etc/ssh/sshd_config
+/usr/bin/sed -i 's/sha1Protocol/sha1\nProtocol/' /etc/ssh/sshd_config
 
 # Clean Up
 rm -rf /root/hardening


### PR DESCRIPTION
Fix a bug with MACs and Protocol being put on same line in /etc/ssh/sshd_config which prevents it from starting correctly.