### PR TITLE
Escape Special Character in UMASK

### DIFF
--- a/config/hardening/ssg-supplemental.sh
+++ b/config/hardening/ssg-supplemental.sh
@@ -393,7 +393,7 @@ cat <<EOF > /etc/profile.d/umask.sh
 
 # Non-Privledged Users get 027
 # Privledged Users get 022
-if [[ $EUID -ne 0 ]]; then
+if [[ \$EUID -ne 0 ]]; then
 	umask 027
 else
 	umask 022


### PR DESCRIPTION
Escaping special character in umask script.